### PR TITLE
Added validation for error code 119.

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -263,3 +263,17 @@ def test_validate_113():
     result = error_func(fake_dfs)
 
     assert result == {'AD1': [2, 3]}
+
+def test_validate_119():
+    fake_data = pd.DataFrame({
+        'DATE_PLACED_CEASED': ['22/11/2015', '08/05/2010', pd.NA, pd.NA],
+        'REASON_PLACED_CEASED': ['XXX',pd.NA, '10/05/2009', pd.NA]
+    })
+
+    fake_dfs = {'PlacedAdoption': fake_data}
+
+    error_defn, error_func = validate_119()
+
+    result = error_func(fake_dfs)
+
+    assert result == {'PlacedAdoption': [1, 2]}

--- a/validator903/config.py
+++ b/validator903/config.py
@@ -35,6 +35,7 @@ configured_errors = [
     validate_113(),
     validate_115(),
     validate_116(),
+    validate_119(),
     validate_143(),
     validate_144(),
     validate_145(),

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -522,3 +522,26 @@ def validate_113():
             return {'AD1': validation_error_locations.tolist()}
     
     return error, _validate
+
+def validate_119():
+    error = ErrorDefinition(
+        code='119',
+        description='If the decision is made that a child should no longer be placed for adoption, then the date of this decision and the reason why this decision was made must be completed.',
+        affected_fields=['REASON_PLACED_CEASED','DATE_PLACED_CEASED'],
+    )
+
+    def _validate(dfs):
+        if 'PlacedAdoption' not in dfs:
+            return {}
+        else:
+            adopt = dfs['PlacedAdoption']
+            na_placed_ceased = adopt['DATE_PLACED_CEASED'].isna()
+            na_reason_ceased = adopt['REASON_PLACED_CEASED'].isna()
+
+            validation_error = (na_placed_ceased & ~na_reason_ceased) | (~na_placed_ceased & na_reason_ceased) 
+            validation_error_locations = adopt.index[validation_error]
+        
+
+            return {'PlacedAdoption': validation_error_locations.tolist()}
+    
+    return error, _validate


### PR DESCRIPTION
validation added to resolve if a child should no longer be placed for adoption, both the date of this decision and the reason why this decision was reached must be recorded.

Closes #24 