### PR TITLE
Added validations for rules 1004 and 1005.

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,34 @@
 from validator903.validators import *
 import pandas as pd
 
+def test_validate_1005():
+    fake_data = pd.DataFrame({
+        'MIS_START': ['08/03/2020','22/06/2020',pd.NA,'13/10/2021','10/24/2021'],
+        'MIS_END': ['08/03/2020',pd.NA,'22/06/2020','13/10/21',pd.NA],
+    })
+
+    fake_dfs = {'Missing': fake_data}
+
+    error_defn, error_func = validate_1005()
+
+    result = error_func(fake_dfs)
+
+    assert result == {'Missing': [3]}
+
+def test_validate_1004():
+    fake_data = pd.DataFrame({
+        'MIS_START': ['08/03/2020','22/06/2020',pd.NA,'13/10/2021','10/24/2021'],
+        'MIS_END': ['08/03/2020',pd.NA,'22/06/2020','13/10/21',pd.NA],
+    })
+
+    fake_dfs = {'Missing': fake_data}
+
+    error_defn, error_func = validate_1004()
+
+    result = error_func(fake_dfs)
+
+    assert result == {'Missing': [2,4]}
+
 def test_validate_621():
     fake_data = pd.DataFrame({
         'DOB': ['01/12/2021', '19/02/2016', '31/01/2019',  '31/01/2019', '31/01/2019'],

--- a/validator903/config.py
+++ b/validator903/config.py
@@ -71,6 +71,8 @@ configured_errors = [
     validate_611(),
     validate_621(),
     validate_631(),
+    validate_1004(),
+    validate_1005(),
     validate_1006(),
     validate_1009(),
     validate_1015(),

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -1,6 +1,58 @@
 import pandas as pd
 from .types import ErrorDefinition
 
+def validate_1005():
+    error = ErrorDefinition(
+        code = '1005',
+        description = 'The end date of the missing episode or episode that the child was away from placement without authorisation is not a valid date.',
+        affected_fields=['MIS_END'],
+    )
+
+    def _validate(dfs):
+        if 'Missing' not in dfs:
+            return {}
+        else:
+            missing = dfs['Missing']
+
+            missing['fMIS_END'] = pd.to_datetime(missing['MIS_END'], format='%d/%m/%Y', errors='coerce')
+
+            missing_end_date = missing['MIS_END'].isna()
+            invalid_end_date = missing['fMIS_END'].isna()
+
+            error_mask = ~missing_end_date & invalid_end_date
+
+            error_locations = missing.index[error_mask]
+
+            return {'Missing': error_locations.to_list()}
+
+    return error, _validate
+
+def validate_1004():
+    error = ErrorDefinition(
+        code = '1004',
+        description = 'The start date of the missing episode or episode that the child was away from placement without authorisation is not a valid date.',
+        affected_fields=['MIS_START'],
+    )
+
+    def _validate(dfs):
+        if 'Missing' not in dfs:
+            return {}
+        else:
+            missing = dfs['Missing']
+
+            missing['fMIS_START'] = pd.to_datetime(missing['MIS_START'], format='%d/%m/%Y', errors='coerce')
+
+            missing_start_date = missing['MIS_START'].isna()
+            invalid_start_date = missing['fMIS_START'].isna()
+
+            error_mask = missing_start_date | invalid_start_date
+
+            error_locations = missing.index[error_mask]
+
+            return {'Missing': error_locations.to_list()}
+
+    return error, _validate
+
 def validate_621():
     error = ErrorDefinition(
         code = '621',


### PR DESCRIPTION
*1004 fires on 'missing' OR invalid start dates
*1005 fires on invalid end dates only ('missing' end is okay as child may still be missing)

Closes #66 and #67 