### PR TITLE
Added validation rule for error 571.

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,25 @@
 from validator903.validators import *
 import pandas as pd
 
+def test_validate_571():
+    fake_data = pd.DataFrame({
+        'MIS_START': ['08/03/2020','22/06/2020',pd.NA,'13/10/2021','10/24/2021'],
+        'MIS_END': ['08/03/2020',pd.NA,'22/06/2020','13/10/21',pd.NA],
+    })
+
+    metadata = { 
+        'collection_start': '01/04/2020',
+        'collection_end': '31/03/2020'
+    }
+
+    fake_dfs = {'Missing': fake_data, 'metadata': metadata}
+
+    error_defn, error_func = validate_571()
+
+    result = error_func(fake_dfs)
+
+    assert result == {'Missing': [0,2]}
+
 def test_validate_621():
     fake_data = pd.DataFrame({
         'DOB': ['01/12/2021', '19/02/2016', '31/01/2019',  '31/01/2019', '31/01/2019'],

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,6 +2,12 @@ from validator903.validators import *
 import pandas as pd
 
 def test_validate_571():
+    
+    fake_data = pd.DataFrame({
+        'MIS_START': ['08/03/2020','22/06/2020',pd.NA,'13/10/2021','10/24/2021'],
+        'MIS_END': ['08/03/2020',pd.NA,'22/06/2020','13/10/21',pd.NA],
+    })
+
     metadata = { 
         'collection_start': '01/04/2020',
         'collection_end': '31/03/2020'

--- a/validator903/config.py
+++ b/validator903/config.py
@@ -88,4 +88,5 @@ configured_errors = [
     validate_502(),
     validate_NoE(),
     validate_567(),
+    validate_571(),
 ]

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -1,6 +1,34 @@
 import pandas as pd
 from .types import ErrorDefinition
 
+def validate_571():
+    error = ErrorDefinition(
+        code = '571',
+        description = 'The date that the child ceased to be missing or away from placement without authorisation is before the start or after the end of the collection year.',
+        affected_fields=['MIS_END'],
+    )
+
+    def _validate(dfs):
+        if 'Missing' not in dfs:
+            return {}
+        else:
+            missing = dfs['Missing']
+            collection_start = pd.to_datetime(dfs['metadata']['collection_start'],format='%d/%m/%Y',errors='coerce')
+            collection_end = pd.to_datetime(dfs['metadata']['collection_start'],format='%d/%m/%Y',errors='coerce')
+
+            missing['fMIS_END'] = pd.to_datetime(missing['MIS_END'], format='%d/%m/%Y', errors='coerce')
+
+            end_date_before_year = missing['fMIS_END'] < collection_start 
+            end_date_after_year = missing['fMIS_END'] > collection_end 
+
+            error_mask = end_date_before_year | end_date_after_year
+
+            error_locations = missing.index[error_mask]
+
+            return {'Missing': error_locations.to_list()}
+
+    return error, _validate
+
 def validate_621():
     error = ErrorDefinition(
         code = '621',


### PR DESCRIPTION
*Error does not trigger on 'missing' end dates (child may still be missing)
*Error does not trigger on invalid end dates (handled by separate validation rule)

Closes #252 