### PR TITLE
Added error 574

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1101,3 +1101,24 @@ def test_validate_1011():
     result = error_func(fake_dfs)
 
     assert result == {'OC3': [0,2,4]}
+
+def test_validate_574():
+    fake_mis = pd.DataFrame([
+    {'CHILD': '111', 'MIS_START' : '01/06/2020', 'MIS_END' : '05/06/2020' }, #0  
+    {'CHILD': '111', 'MIS_START' : '04/06/2020', 'MIS_END' : pd.NA },        #1 Fails overlaps
+    {'CHILD': '222', 'MIS_START' : '03/06/2020', 'MIS_END' : '04/06/2020' }, #2 
+    {'CHILD': '222', 'MIS_START' : '04/06/2020', 'MIS_END' : pd.NA },        #3 
+    {'CHILD': '222', 'MIS_START' : '07/06/2020', 'MIS_END' : '09/06/2020' }, #4 Fails, previous end is null 
+    {'CHILD': '333', 'MIS_START' : '02/06/2020', 'MIS_END' : '04/06/2020' }, #5
+    {'CHILD': '333', 'MIS_START' : '03/06/2020', 'MIS_END' : '09/06/2020' }, #6 Fails overlaps
+    {'CHILD': '555', 'MIS_START' : pd.NA,        'MIS_END' : '05/06/2020' }, #7  
+    {'CHILD': '555', 'MIS_START' : pd.NA,        'MIS_END' : '05/06/2020' }, #8  
+    ])
+
+    fake_dfs = {'Missing': fake_mis}
+
+    error_defn, error_func = validate_574()
+
+    result = error_func(fake_dfs)
+    
+    assert result == {'Missing': [1,4,6]}

--- a/validator903/config.py
+++ b/validator903/config.py
@@ -96,4 +96,5 @@ configured_errors = [
     validate_304(),
     validate_333(),
     validate_1011(),
+    validate_574(),
 ]


### PR DESCRIPTION
Added 574.

Note in the coding description it reads:
If provided <MIS_START> from current Missing occurrence must be >= previous Missing occurrence <MIS_START> and
previous Missing occurrence <MIS_END> cannot be Null

It should be <MIS_START> must be >= previous <MIS_END> and <MIS_END> can't be null , otherwise it doesn't make sense.