### PR TITLE
get _add_postcode_details function to work for welsh, scottish and irish postcodes

### DIFF
--- a/.breakpoints
+++ b/.breakpoints
@@ -1,0 +1,18 @@
+{
+  "files": {
+    "validator903/datastore.py": [
+      {
+        "id": "dd9abf1b-5219-48be-a3e0-76f6cbcf891e",
+        "line": 16,
+        "version": 1,
+        "index": 292
+      },
+      {
+        "id": "4f02e106-2187-4de8-98c4-f217a2261a72",
+        "line": 81,
+        "version": 1,
+        "index": 3057
+      }
+    ]
+  }
+}

--- a/validator903/datastore.py
+++ b/validator903/datastore.py
@@ -93,21 +93,26 @@ def merge_postcodes(df: DataFrame, postcode_field: str) -> DataFrame:
 
 def _add_postcode_derived_fields(episodes_df, local_authority):
     episodes_df = episodes_df.copy()
+
     home_details = merge_postcodes(episodes_df, "HOME_POST")
     pl_details = merge_postcodes(episodes_df, "PL_POST")
 
     # The indices remain the same post merge as the length of the dataframes doesn't change, so we can set directly.
     pl_details = pl_details.merge(la_df, how='left', left_on='laua', right_on='LTLA21CD')
     episodes_df['PL_LA'] = pl_details['UTLA21CD']
-    first_letter = pl_details['laua'].str.upper().get(0)
-    episodes_df.loc[first_letter=='S', 'PL_LA'] = 'SCO'
-    episodes_df.loc[first_letter=='N', 'PL_LA'] = 'NIR'
-    episodes_df.loc[first_letter=='W', 'PL_LA'] = 'WAL'
 
     logger.info(f"Adding IN/OUT")
     episodes_df['PL_LOCATION'] = 'IN'
     episodes_df.loc[episodes_df['PL_LA'].ne(local_authority), 'PL_LOCATION'] = 'OUT'
-    episodes_df.loc[episodes_df['oseast1m'].isna(), 'PL_LOCATION'] = pd.NA
+    episodes_df.loc[pl_details['laua'].isna(), 'PL_LOCATION'] = pd.NA
+
+    # Add country codes for placements outside england
+    for letter, code in {'S': 'SCO', 'N': 'NIR', 'W': 'WAL'}.items():
+        mask = (
+            pl_details['laua'].str.upper().str.startswith(letter)
+            & episodes_df['PL_POST'].notnull()
+        )
+        episodes_df.loc[mask, ['PL_LA', 'PL_LOCATION']] = [code, 'OUT']
 
     logger.info(f"Calculating distances")
     # This formula is taken straight from the guidance, to get miles between two postcodes

--- a/validator903/datastore.py
+++ b/validator903/datastore.py
@@ -96,7 +96,7 @@ def _add_postcode_derived_fields(episodes_df, local_authority):
     home_details = merge_postcodes(episodes_df, "HOME_POST")
     pl_details = merge_postcodes(episodes_df, "PL_POST")
 
-    # The indexes remain the same post merge as the length of the dataframes doesn't change, so we can set directly.
+    # The indices remain the same post merge as the length of the dataframes doesn't change, so we can set directly.
     pl_details = pl_details.merge(la_df, how='left', left_on='laua', right_on='LTLA21CD')
     episodes_df['PL_LA'] = pl_details['UTLA21CD']
     first_letter = pl_details['laua'].str.upper().get(0)

--- a/validator903/datastore.py
+++ b/validator903/datastore.py
@@ -99,11 +99,15 @@ def _add_postcode_derived_fields(episodes_df, local_authority):
     # The indexes remain the same post merge as the length of the dataframes doesn't change, so we can set directly.
     pl_details = pl_details.merge(la_df, how='left', left_on='laua', right_on='LTLA21CD')
     episodes_df['PL_LA'] = pl_details['UTLA21CD']
+    first_letter = pl_details['laua'].str.upper().get(0)
+    episodes_df.loc[first_letter=='S', 'PL_LA'] = 'SCO'
+    episodes_df.loc[first_letter=='N', 'PL_LA'] = 'NIR'
+    episodes_df.loc[first_letter=='W', 'PL_LA'] = 'WAL'
 
     logger.info(f"Adding IN/OUT")
     episodes_df['PL_LOCATION'] = 'IN'
     episodes_df.loc[episodes_df['PL_LA'].ne(local_authority), 'PL_LOCATION'] = 'OUT'
-    episodes_df.loc[episodes_df['PL_LA'].isna(), 'PL_LOCATION'] = pd.NA
+    episodes_df.loc[episodes_df['oseast1m'].isna(), 'PL_LOCATION'] = pd.NA
 
     logger.info(f"Calculating distances")
     # This formula is taken straight from the guidance, to get miles between two postcodes

--- a/validator903/utils.py
+++ b/validator903/utils.py
@@ -51,7 +51,9 @@ def add_col_to_episodes_CONTINUOUSLY_LOOKED_AFTER(episodes, collection_start, co
     in_care_at_some_point = eps_copy.groupby('CHILD')['during_year'].transform('max')
     not_in_care_at_some_point = eps_copy.groupby('CHILD')['implies_not_continuous'].transform('max')
 
-    episodes['CONTINUOUSLY_LOOKED_AFTER'] = in_care_at_some_point & ~not_in_care_at_some_point
+    # the "== True/False" is to cope with weird situations which cause these to potentially be float dtype,
+    # which i don't have time to get into right now, but may be to do with missing DECOMs
+    episodes['CONTINUOUSLY_LOOKED_AFTER'] = (in_care_at_some_point == True) & (not_in_care_at_some_point == False)
 
     return episodes
 


### PR DESCRIPTION
Changes provide more descriptive values for PL_LA when the local authority is in Scotland or Northern Ireland. Also, a local authority found out of the UK no longer is mapped to a null PL_LOCATION.

Closes #550 