### PR TITLE
Update rules 131, 132 and 133 to flag null values

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3656,7 +3656,7 @@ def test_validate_131():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [0, 2, 3, 5]}
+    assert result == {'OC3': [0, 2, 3, 5, 6]}
 
 
 def test_validate_120():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2315,7 +2315,7 @@ def test_validate_133():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [5, 6]}
+    assert result == {'OC3': [2, 5, 6]}
 
 
 def test_validate_565():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3642,7 +3642,7 @@ def test_validate_132():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [0, 2, 4, 6]}
+    assert result == {'OC3': [0, 2, 4, 6, 7]}
 
 
 def test_validate_131():

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -3057,7 +3057,7 @@ def validate_133():
                            'R2', 'S2', 'T1', 'T2', 'U1', 'U2', 'V1', 'V2', 'W1', 'W2', 'X2', 'Y1', 'Y2', 'Z1', 'Z2',
                            '0']
 
-            error_mask = ~oc3['ACCOM'].isna() & ~oc3['ACCOM'].isin(valid_codes)
+            error_mask = ~oc3['ACCOM'].isin(valid_codes)
 
             error_locations = oc3.index[error_mask]
 

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -5159,7 +5159,7 @@ def validate_132():
             'G6',
             '0'
         ]
-        mask = care_leavers['ACTIV'].astype(str).isin(code_list) | care_leavers['ACTIV'].isna()
+        mask = care_leavers['ACTIV'].astype(str).isin(code_list)
 
         validation_error_mask = ~mask
         validation_error_locations = care_leavers.index[validation_error_mask]

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -5189,7 +5189,7 @@ def validate_131():
             'NREQ',
             'RHOM'
         ]
-        mask = care_leavers['IN_TOUCH'].isin(code_list) | care_leavers['IN_TOUCH'].isna()
+        mask = care_leavers['IN_TOUCH'].isin(code_list)
 
         validation_error_mask = ~mask
         validation_error_locations = care_leavers.index[validation_error_mask]


### PR DESCRIPTION
Closes #579 

Note: This change is required for CSV source files however am unclear on the correct behaviour for XML source files.  It may be that the logic in these rules need to branch based on the 'file_format' value in metadata.