### PR TITLE
Amend rule 442 (remove duplication in returned errors)

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2315,7 +2315,7 @@ def test_validate_133():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [2, 5, 6]}
+    assert result == {'OC3': [5, 6]}
 
 
 def test_validate_565():
@@ -3642,7 +3642,7 @@ def test_validate_132():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [0, 2, 4, 6, 7]}
+    assert result == {'OC3': [0, 2, 4, 6]}
 
 
 def test_validate_131():
@@ -3656,7 +3656,7 @@ def test_validate_131():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [0, 2, 3, 5, 6]}
+    assert result == {'OC3': [0, 2, 3, 5]}
 
 
 def test_validate_120():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2114,7 +2114,7 @@ def test_validate_442():
     error_defn, error_func = validate_442()
     result = error_func(fake_dfs)
 
-    assert result == {'Episodes': [0, 4, 7], 'Header': [0, 4]}
+    assert result == {'Header': [0, 4]}
 
 
 def test_validate_344():
@@ -2315,7 +2315,7 @@ def test_validate_133():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [5, 6]}
+    assert result == {'OC3': [2, 5, 6]}
 
 
 def test_validate_565():
@@ -3642,7 +3642,7 @@ def test_validate_132():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [0, 2, 4, 6]}
+    assert result == {'OC3': [0, 2, 4, 6, 7]}
 
 
 def test_validate_131():
@@ -3656,7 +3656,7 @@ def test_validate_131():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC3': [0, 2, 3, 5]}
+    assert result == {'OC3': [0, 2, 3, 5, 6]}
 
 
 def test_validate_120():

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -2710,14 +2710,13 @@ def validate_442():
 
             code_list = ['V3', 'V4']
 
-            # merge left on episodes to get all children for which episodes have been recorded even if they do not exist on the header.
-            merged = episodes.merge(header, on=['CHILD'], how='left', suffixes=['_eps', '_er'])
+            # merge to get all children for which episodes have been recorded.
+            merged = episodes.merge(header, on=['CHILD'], how='inner', suffixes=['_eps', '_er'])
             # Where any episode present, with an <LS> not = 'V3' or 'V4' then <UPN> must be provided
             mask = (~merged['LS'].isin(code_list)) & merged['UPN'].isna()
-            episode_error_locs = merged.loc[mask, 'index_eps']
             header_error_locs = merged.loc[mask, 'index_er']
 
-            return {'Episodes': episode_error_locs.tolist(),
+            return {
                     # Select unique values since many episodes are joined to one header
                     # and multiple errors will be raised for the same index.
                     'Header': header_error_locs.dropna().unique().tolist()}


### PR DESCRIPTION
Episodes do not need to be included in the highlighted errors for this rule.  Any child existing in episodes but not in header should be picked up in separate validations (see #347).