### PR TITLE
Updated rule 191 to handle when CHILD is missing from OC2 entirely (but is continuously looked after)

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2973,7 +2973,7 @@ def test_validate_191():
 
     result = error_func(fake_dfs)
 
-    assert result == {'OC2': [1, 6]}
+    assert result == {'OC2': [1, 6], 'Episodes':[3]}
 
 
 def test_validate_516():


### PR DESCRIPTION
Closes #589 