### PR TITLE
Update Rule 207 to exclude care leavers

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3169,7 +3169,7 @@ def test_validate_207():
     })
 
     fake_episodes = pd.DataFrame({
-        'CHILD': ['101', '102', '103', '104', '105', '106', '107', '108', '109', '110'],
+        'CHILD': ['101', '101', '102', '103', '104', '105', '106', '107', '108', '109', '110'],
     })
 
     fake_dfs = {'Header': fake_data, 'Header_last': fake_data_prev, 'Episodes': fake_episodes}

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3159,16 +3159,20 @@ def test_validate_557():
 
 def test_validate_207():
     fake_data = pd.DataFrame({
-        'CHILD': ['101', '102', '103', '104', '105', '106', '108', '109', '110'],
-        'MOTHER': ['1', 0, '1', pd.NA, pd.NA, '1', pd.NA, '0', '2'],
+        'CHILD': ['101', '102', '103', '104', '105', '106', '108', '109', '110', '111'],
+        'MOTHER': ['1', 0, '1', pd.NA, pd.NA, '1', pd.NA, '0', '2', pd.NA],
     })
 
     fake_data_prev = pd.DataFrame({
-        'CHILD': ['101', '102', '103', '104', '105', '107', '108', '109', '110'],
-        'MOTHER': ['1', 1, '0', 1, pd.NA, '1', '0', pd.NA, '1'],
+        'CHILD': ['101', '102', '103', '104', '105', '107', '108', '109', '110', '111'],
+        'MOTHER': ['1', 1, '0', 1, pd.NA, '1', '0', pd.NA, '1', '1'],
     })
 
-    fake_dfs = {'Header': fake_data, 'Header_last': fake_data_prev}
+    fake_episodes = pd.DataFrame({
+        'CHILD': ['101', '102', '103', '104', '105', '106', '107', '108', '109', '110'],
+    })
+
+    fake_dfs = {'Header': fake_data, 'Header_last': fake_data_prev, 'Episodes': fake_episodes}
 
     error_defn, error_func = validate_207()
 

--- a/validator903/validators.py
+++ b/validator903/validators.py
@@ -4721,7 +4721,7 @@ def validate_207():
             header_last = dfs['Header_last']
             episodes = dfs['Episodes']
 
-            header.reset_index()
+            header.reset_index(inplace=True)
           
             header_merged = header.merge(header_last, how='left', on=['CHILD'], suffixes=('', '_last'),
                                                        indicator=True)
@@ -4735,9 +4735,9 @@ def validate_207():
 
             error_mask = in_both_years & ~has_no_episodes & mother_is_different & mother_was_true
 
-            error_locations = header.index[error_mask]
+            error_locations = list(header_merged.loc[error_mask, 'index'].unique())
 
-            return {'Header': error_locations.to_list()}
+            return {'Header': error_locations}
 
     return error, _validate
 


### PR DESCRIPTION
Closes #600 

- Exclude children with no episodes in-year (shortcut for care leavers with no episodes).
- Update tests to suit.
