### PR TITLE
Update run-tests.yml to python3.9 for validator integration

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,22 +8,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9] # Pandas takes forever to build on 3.9 - if we test on 3.8 it should be pretty safe
+        python-version: [3.9] 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry 📜
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@v2
 
       - name: Cache dependencies
         id: cached-poetry-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-poetry-deps
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8] # Pandas takes forever to build on 3.9 - if we test on 3.8 it should be pretty safe
+        python-version: [3.9] # Pandas takes forever to build on 3.9 - if we test on 3.8 it should be pretty safe
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
cin_validator runs on python3.9 so lac is being updated to match it.