### PR TITLE
manage registry within package of year rules

### DIFF
--- a/lac_validator/__main__.py
+++ b/lac_validator/__main__.py
@@ -12,7 +12,6 @@ from lac_validator.utils import process_uploaded_files
 from validator903.ingress import read_from_text
 from validator903.report import Report
 
-
 @click.group()
 def cli():
     pass

--- a/lac_validator/__main__.py
+++ b/lac_validator/__main__.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 
 import lac_validator.lac_validator_class as lac_class
-from lac_validator.ruleset import create_registry
 import importlib
 from lac_validator.utils import process_uploaded_files
 
@@ -33,8 +32,9 @@ def list_cmd(ruleset):
 
     :return cli output: list of rules in validation year.
     """
-    registry = create_registry(ruleset=ruleset)
-    for rule in registry:
+    module = importlib.import_module(f"lac_validator.rules.{ruleset}")
+    ruleset_registry = getattr(module, "registry")
+    for rule in ruleset_registry:
         click.echo(f"{rule.code}\t{rule.message}")
 
 
@@ -118,7 +118,7 @@ def run_all(p4a_path, ad1_path, ruleset, select):
 
     # the rest of the metadata is added in read_from_text() when instantiating Validator
     metadata = {"collectionYear": "2022", "localAuthority": "E09000027"}
-    module = importlib.import_module("lac_validator.rules.lac2022_23")
+    module = importlib.import_module(f"lac_validator.rules.{ruleset}")
     ruleset_registry = getattr(module, "registry")
 
     v = lac_class.LacValidator(metadata=metadata, files=files_list, registry=ruleset_registry, selected_rules=None)

--- a/lac_validator/__main__.py
+++ b/lac_validator/__main__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import lac_validator.lac_validator_class as lac_class
 from lac_validator.ruleset import create_registry
+import importlib
 from lac_validator.utils import process_uploaded_files
 
 from validator903.ingress import read_from_text
@@ -117,13 +118,13 @@ def run_all(p4a_path, ad1_path, ruleset, select):
 
     # the rest of the metadata is added in read_from_text() when instantiating Validator
     metadata = {"collectionYear": "2022", "localAuthority": "E09000027"}
+    module = importlib.import_module("lac_validator.rules.lac2022_23")
+    ruleset_registry = getattr(module, "registry")
 
-    v = lac_class.LacValidator(
-        metadata=metadata, files=files_list, ruleset=ruleset, selected_rules=None
-    )
+    v = lac_class.LacValidator(metadata=metadata, files=files_list, registry=ruleset_registry, selected_rules=None)
     results = v.ds_results
 
-    r = Report(results)
+    r = Report(results, ruleset=ruleset_registry)
     print(f"*****************Report******************")
     print(r.report)
     print(f"*****************Error report******************")

--- a/lac_validator/lac_validator_class.py
+++ b/lac_validator/lac_validator_class.py
@@ -9,7 +9,7 @@ from validator903.datastore import copy_datastore, create_datastore
 
 logger = logging.getLogger(__name__)
 
-# TODO rename this file
+# TODO rename this file so that it doesn't have class in its name.
 class LacValidator:
     """
     Central location for running rules on files.

--- a/lac_validator/lac_validator_class.py
+++ b/lac_validator/lac_validator_class.py
@@ -1,5 +1,4 @@
 import logging
-import datetime
 import pandas as pd
 from typing import Any
 from pandas import DataFrame
@@ -7,8 +6,6 @@ from pandas import DataFrame
 from validator903.types import UploadedFile
 from validator903.ingress import read_from_text
 from validator903.datastore import copy_datastore, create_datastore
-
-from lac_validator.ruleset import create_registry
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +19,7 @@ class LacValidator:
         self,
         metadata: dict[str, Any],
         files: list[UploadedFile],
-        ruleset,
+        registry,
         selected_rules,
     ):
         self.dfs: dict[str, DataFrame] = {}
@@ -37,7 +34,7 @@ class LacValidator:
         metadata.update(metadata_extras)
         logger.info(f'Metadata receieved: {",".join(metadata.keys())}')
 
-        self.ruleset = ruleset
+        self.registry = registry
         self.metadata = metadata
 
         # validate
@@ -62,8 +59,7 @@ class LacValidator:
         logger.info("Creating Data store...")
         data_store = create_datastore(self.dfs, self.metadata)
 
-        registry = create_registry(self.ruleset)
-        rules_to_run = self.get_rules_to_run(registry, selected_rules)
+        rules_to_run = self.get_rules_to_run(self.registry, selected_rules)
 
         # this corresponds to raw_data in CINvalidationSession
         self.ds_results = copy_datastore(data_store)

--- a/lac_validator/rule_engine/__api.py
+++ b/lac_validator/rule_engine/__api.py
@@ -1,6 +1,6 @@
 import importlib
 from dataclasses import dataclass
-from typing import Callable, Iterable
+from typing import Callable, Optional
 
 
 @dataclass(frozen=True, eq=True)
@@ -18,10 +18,10 @@ class RuleDefinition:
     :rtype: dataclass object.
     """
 
-    code: int
+    code: str
     func: Callable
-    message: str = None
-    affected_fields: Iterable[str] = None
+    message: Optional[str]= None,
+    affected_fields: Optional[list[str]]= None,
 
     @property
     def code_module(self):

--- a/lac_validator/rule_engine/__api.py
+++ b/lac_validator/rule_engine/__api.py
@@ -20,9 +20,9 @@ class RuleDefinition:
 
     code: str
     func: Callable
-    message: Optional[str]= None,
-    affected_fields: Optional[list[str]]= None,
-
+    message: Optional[str]= None
+    affected_fields: Optional[list[str]]= None
     @property
     def code_module(self):
+        # TODO check if this line is still necessary after recent changes to registry.
         return importlib.import_module(self.func.__module__)

--- a/lac_validator/rule_engine/__registry.py
+++ b/lac_validator/rule_engine/__registry.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 from lac_validator.rule_engine.__api import RuleDefinition
 
 
+# TODO check how this structure needs to be changed to accomodate the fact that registry is now in array-format and no longer dict
 class __Registry:
     """Contains information about all validation rules including definition and issue error locations. Allows iterating through validation rules."""
 
@@ -15,6 +16,9 @@ class __Registry:
         # self._registry = {}
         self._registry = []
 
+    # TODO Define registry objects (in the init files of the rule packages) with the Registry class type.
+    # such that this (or something like it) can be done registry2023_24 = registry2022_23.add(rule_revisions2023_24) where rule_revisions2023_24 can be addition, deletion or modification of rules in previous year according to str rule codes.
+    # get inspiration from how it was implemented (inefficiently) here: lac_validator\ruleset.py
     def add(self, rd: RuleDefinition):
         """
         Adds rules to the registry for iterating through and validating.
@@ -125,8 +129,6 @@ def rule_definition(
             message=message,
             affected_fields=affected_fields,
         )
-        # registry.add(definition)
-
         # when validator funcs are created, give them a unique attribute that they can be 
         # recognised by when the file is read later.
         wrapper.rule = definition

--- a/lac_validator/rule_engine/__registry.py
+++ b/lac_validator/rule_engine/__registry.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Iterable
+from typing import Callable, Optional
 from lac_validator.rule_engine.__api import RuleDefinition
 
 
@@ -12,7 +12,8 @@ class __Registry:
         RuleDefinitions.
         """
 
-        self._registry = {}
+        # self._registry = {}
+        self._registry = []
 
     def add(self, rd: RuleDefinition):
         """
@@ -97,9 +98,9 @@ registry = __Registry()
 
 
 def rule_definition(
-    code: int,
-    message: str = None,
-    affected_fields: Iterable[str] = None,
+    code: str,
+    message: Optional[str] = None,
+    affected_fields: Optional[list[str]] = None,
 ):
     """
     Creates the rule definition for validation rules using RuleDefinition class as a template.
@@ -124,8 +125,11 @@ def rule_definition(
             message=message,
             affected_fields=affected_fields,
         )
-        registry.add(definition)
-        wrapper.__rule_def__ = definition
+        # registry.add(definition)
+
+        # when validator funcs are created, give them a unique attribute that they can be 
+        # recognised by when the file is read later.
+        wrapper.rule = definition
         return wrapper
 
     return decorator

--- a/lac_validator/rules/lac2022_23/__init__.py
+++ b/lac_validator/rules/lac2022_23/__init__.py
@@ -1,8 +1,14 @@
 import importlib
 from pathlib import Path
 
+# TODO build out how this init file should look like next year. 
+# the init files of each next year should import the rule package of the previous year
+# and return a new registry that reflects the rule revisions of that year. e.g take rules A, B as-is, modify rule C and ignore/delete/do-not-run rule D, and take rule E as-is
+# So the __init__.py file of lac202_23 should import the 
+
 files = [p.stem for p in Path(__file__).parent.glob("*.py") if p.stem != "__init__"]
 
+# TODO registry should be of Registry type (class in lac_validator\rule_engine\__registry.py)
 registry = []
 for rule_file in files:
     # get all the elements (functions, classes, variables) of the file and their attributes.
@@ -10,6 +16,7 @@ for rule_file in files:
     rule_elements = {n:getattr(rule_content, n) for n in dir(rule_content)}
     # all validator functions have a decorator which attaches a "rule" attribute to them.
     validator_funcs = [v.rule for k, v in rule_elements.items() if hasattr(v, "rule")]
+    # TODO reevaluate if validator_funcs should be a list or a dict, considering how easy it will be to compare rules present/absent/modified across years
     registry.extend(validator_funcs)
 
 __all__=["registry"]

--- a/lac_validator/rules/lac2022_23/__init__.py
+++ b/lac_validator/rules/lac2022_23/__init__.py
@@ -13,7 +13,3 @@ for rule_file in files:
     registry.extend(validator_funcs)
 
 __all__=["registry"]
-
-# TODO now this line has to be commented for tests to run and uncommented for validation to run.
-# else it loads the registry twice and says that the rules are duplicates.
-# from . import * 

--- a/lac_validator/rules/lac2022_23/__init__.py
+++ b/lac_validator/rules/lac2022_23/__init__.py
@@ -1,7 +1,19 @@
+import importlib
 from pathlib import Path
 
-__all__ = [p.stem for p in Path(__file__).parent.glob("*.py") if p.stem != "__init__"]
+files = [p.stem for p in Path(__file__).parent.glob("*.py") if p.stem != "__init__"]
+
+registry = []
+for rule_file in files:
+    # get all the elements (functions, classes, variables) of the file and their attributes.
+    rule_content = importlib.import_module(f"lac_validator.rules.lac2022_23.{rule_file}")
+    rule_elements = {n:getattr(rule_content, n) for n in dir(rule_content)}
+    # all validator functions have a decorator which attaches a "rule" attribute to them.
+    validator_funcs = [v.rule for k, v in rule_elements.items() if hasattr(v, "rule")]
+    registry.extend(validator_funcs)
+
+__all__=["registry"]
 
 # TODO now this line has to be commented for tests to run and uncommented for validation to run.
 # else it loads the registry twice and says that the rules are duplicates.
-from . import *
+# from . import * 

--- a/lac_validator/ruleset.py
+++ b/lac_validator/ruleset.py
@@ -1,3 +1,5 @@
+# TODO implement update registry as function here https://github.com/data-to-insight/quality-lac-data-beta-validator/pull/648#discussion_r1224480979
+
 from lac_validator.rule_engine import registry
 
 ruleset_updates = {}

--- a/lac_validator/utils.py
+++ b/lac_validator/utils.py
@@ -1,10 +1,9 @@
 from validator903.types import UploadedFile, UploadError
 from prpc_python.pyodide import PyodideFile
 from io import TextIOWrapper
- 
-# TODO Test that this function still works
-# TODO list[UploadedFile | PyodideFile | str]
-# TODO update to python3.10
+
+# list[UploadedFile | PyodideFile | str] is syntax that is available only in python 3.10
+# TODO update to python3.10 there is no particular reason why this project needs to be 3.9
 
 def process_uploaded_files(input_files:dict[str, list]):
     """

--- a/rpc_main.py
+++ b/rpc_main.py
@@ -24,7 +24,7 @@ logger.addHandler(handler)
 
 app = RpcApp("validate_lac")
 @app.call
-def get_rules(ruleset:str="lac2022_23")->list[dict]:
+def get_rules(ruleset:str="lac2022_23")->str:
     """
     :param str ruleset: validation ruleset according to year published.
     :return rules_df: available rule codes and definitions according to chosen ruleset.

--- a/validator903/report.py
+++ b/validator903/report.py
@@ -7,8 +7,6 @@ from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
 from openpyxl.worksheet.table import Table, TableStyleInfo
 
-from lac_validator.ruleset import create_registry
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
**Context of changes**

At first the decorator attached to validate rules [automatically added them](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/f1354183037ec4a224af9d60130f045db4d60713/lac_validator/rule_engine/__registry.py#L127) to registry whenever a file containing a validate function was opened. 
This caused conflicts because when the files needed to be opened twice (e.g in the case of [loading and running pytest](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/f1354183037ec4a224af9d60130f045db4d60713/lac_validator/__main__.py#L48)) the registry flagged all rules as duplicates.
As such, [this line](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/f1354183037ec4a224af9d60130f045db4d60713/lac_validator/rules/lac2022_23/__init__.py#L7) had to be commented to test the rules (`python -m lac_validator test`) and then uncommented to run the rules (`python -m lac_validator run tests\\fake_data\placed_for_adoption_errors.csv tests\\fake_data\\ad1.csv`)
The changes in this pull request fix that so that toggling is no longer necessary. It does this by [attaching a tag](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/0ed8ba1998b8087b68c951d56a74009c7157cfdf/lac_validator/rule_engine/__registry.py#L134), the ".rule" attribute in this case, that validator rules can be recognised by so that they can be filtered out and added to the registry only when needed.

**Handover TODOs**
- [ ] Rename file lac_validator_class to `lac_validator.py`
- [ ] Drag files that are being imported from validator903 into the lac_validator folder. Allow vs_code to auto-update the imports  so that they now point to lac_validator.
- [ ] Use new registry format to define relationship between years when new rulesets are created. all the TODOs about init and registry refer to this. [This commit ](https://github.com/data-to-insight/quality-lac-data-beta-validator/pull/648/commits/0ed8ba1998b8087b68c951d56a74009c7157cfdf)contains annotations of where the code might need to be changed.

**Notes about the repo.**
- _Day to day changes:_ treat the `feat/code-refactor` branch as the parent branch of all changes. Create branches from it and make pull requests to it. 
- Keeping track of state of code in frontend: Build the wheel (`poetry-build`) from the `feat/code-refactor` branch whenever the frontend needs to be updated. Then merge the `feat/code-refactor` branch into its parent (`refactor/migration`) so that day-to-day merging can keep going on on the `feat/code-refactor` branch while knowing that the `refactor/migration` branch is a reflection of the code being run  in the frontend. This aids in debugging python errors that can arise in the frontend.
- The priority is getting things done. So if that means deleting or totally rewriting large blocks of logic, absolutely do that. I'm not attached to this lines of code. Delete away.
