### PR TITLE
Fix/unrecognised file error

### DIFF
--- a/lac_validator/utils.py
+++ b/lac_validator/utils.py
@@ -1,5 +1,4 @@
 from validator903.types import UploadedFile, UploadError
-from prpc_python.pyodide import PyodideFile
 from io import TextIOWrapper
 
 # list[UploadedFile | PyodideFile | str] is syntax that is available only in python 3.10
@@ -20,11 +19,10 @@ def process_uploaded_files(input_files:dict[str, list]):
     for field_name, file_refs in input_files.items():
         for file_ref in file_refs:
             # name attribute depends on whether on file type. CLI and API send different types.
-            if isinstance(file_ref, PyodideFile):         
-                # PyodideFile from frontend
-                filename = file_ref.filename
+            try:
                 file_text = file_ref.read()
-            else:
+                filename = file_ref.filename
+            except AttributeError:
                 if isinstance(file_ref, TextIOWrapper):
                     # Text IO wrapper object from command line
                     filename = file_ref.name                   


### PR DESCRIPTION
The file sent by the frontend was of type rpc_wrap.PyodideFile not PyodideFile. 
This caused it not to be recognised by the backend file processor.

The changes in this pull request make the backend more generalisable and removes the explicit check for a particular frontend-generated filetype.