### PR TITLE
qlacref env var

### DIFF
--- a/lac_validator/datastore.py
+++ b/lac_validator/datastore.py
@@ -12,6 +12,9 @@ from qlacref_postcodes import Postcodes
 
 logger = logging.getLogger(__name__)
 
+# TODO security point. remove this line.
+os.environ["QLACREF_PC_INSECURE"] = "True"
+
 la_df = pd.DataFrame.from_records(qlacref_authorities.records)
 logger.info("Loaded authorities")
 


### PR DESCRIPTION
When the QLACREF_PC_INSECURE env variable is manually assigned to the public key, it works on local but doesn't work on pyodide.
One thing leads to another and a spiral of debugging ensues.
Deprioritising this in the meantime.