### PR TITLE
bump up 903 version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lac-validator"
-version = "1.0.3"
+version = "2.0.0"
 description = "Shared module for validating the ruleset on the SSDA903 census using DfE rules."
 authors = [
     "Mark Waddoups <mark.waddoups@socialfinance.org.uk>",


### PR DESCRIPTION
The repo has changed significantly as it was refactored to follow the better architecture principles which were implemented in the CIN tool.

- There have been significant changes to simplify the developer experience. The new repo is more modular with one file per rule and rules kept side-by-side with their tests. 
- API endpoints are now well-defined in a separate file (rpc_main) and the backend-frontend pyodide interaction is gracefully managed by the rpc_wrap package.
- The output from the backend that feeds into the frontend display tables has been restructured to suit a standardised format, similar to that on the cin validator tool. As such, a common frontend works for both validators. Hence a second validator has been built without increasing the maintenance overhead of the frontend.

There has been no change in the logic of the validator itself. It produces the same validation results as it did before the refactor, as expected.