### PR TITLE
1016 working

### DIFF
--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -38,25 +38,28 @@ def validate(dfs):
 
         # Fails rows where the child is between 19 and 17 at the end of a return,
         # and their DEC is after their 17th birthday
-        df_merged['age at dec'] = (df_merged['DEC'] - df_merged['DOB']) / np.timedelta64(1, "Y")
-    
-        condition_17 = df_merged["DEC"] >= (df_merged["DOB"] + pd.offsets.DateOffset(years=17))
-        condition_18 = df_merged["DEC"] >= (df_merged["DOB"] + pd.offsets.DateOffset(years=18))
-        print(df_merged)
-        print(df_merged[condition_18])
+        df_merged["age at dec"] = (
+            df_merged["DEC"] - df_merged["DOB"]
+        ) / np.timedelta64(1, "Y")
+
+        condition_17 = df_merged["DEC"] >= (
+            df_merged["DOB"] + pd.offsets.DateOffset(years=17)
+        )
+        condition_18 = df_merged["DEC"] >= (
+            df_merged["DOB"] + pd.offsets.DateOffset(years=18)
+        )
 
         df_errors = df_merged[
             (
-                (df_merged["AGE_AT_CE"] >= np.timedelta64(17, "Y")) & 
-                 (df_merged["AGE_AT_CE"] < np.timedelta64(18, "Y"))  & 
-                 condition_17
-                 )
+                (df_merged["AGE_AT_CE"] >= np.timedelta64(17, "Y"))
+                & (df_merged["AGE_AT_CE"] < np.timedelta64(18, "Y"))
+                & condition_17
+            )
             | (
-                (df_merged["AGE_AT_CE"] >= np.timedelta64(18, "Y")) & 
-                 (df_merged["AGE_AT_CE"] < np.timedelta64(19, "Y")) & 
-                 condition_18
-                 )
-            
+                (df_merged["AGE_AT_CE"] >= np.timedelta64(18, "Y"))
+                & (df_merged["AGE_AT_CE"] < np.timedelta64(19, "Y"))
+                & condition_18
+            )
         ]
 
         df_errors = df_errors[
@@ -81,14 +84,14 @@ def test_validate():
                 "ACCOM": "Y",
             },
             {
-                "CHILD": "child2", 
+                "CHILD": "child2",
                 "DOB": "01/01/2001",
                 "IN_TOUCH": pd.NA,
                 "ACTIV": pd.NA,
                 "ACCOM": pd.NA,
             },
             {
-                "CHILD": "child3", 
+                "CHILD": "child3",
                 "DOB": "01/01/2000",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
@@ -148,15 +151,30 @@ def test_validate():
 
     fake_epi = pd.DataFrame(
         [
-            {"CHILD": "child1", "DEC": "31/03/2020"}, # 18 within collection year and BDAY on DEC,  FAIL
-            {"CHILD": "child2", "DEC": pd.NA}, # Pass no DEC
-            {"CHILD": "child3", "DEC": pd.NA}, # Pass no DEC
-            {"CHILD": "child4", "DEC": "01/01/2020"}, # Born 01/01/2002, 18 before DEC, FAIL
-            {"CHILD": "child6", "DEC": pd.NA}, # Pass no DEC
-            {"CHILD": "child4", "DEC": pd.NA}, # Pass no DEC
-            {"CHILD": "child8", "DEC": "30/03/2020"}, # Born 31/03/2002, within collection year 18 & DEC, but  DEC before BDAY, PASS
-            {"CHILD": "child9", "DEC": "02/04/2019"}, # Born 01/04/2002, within collection birthday 17 & DEC before BDAY, FAIL
-            {"CHILD": "child10", "DEC": "02/04/2019"}, # Born 01/04/2001, within collection birthday 18 & DEC before BDAY, FAIL
+            {
+                "CHILD": "child1",
+                "DEC": "31/03/2020",
+            },  # 18 within collection year and BDAY on DEC,  FAIL
+            {"CHILD": "child2", "DEC": pd.NA},  # Pass no DEC
+            {"CHILD": "child3", "DEC": pd.NA},  # Pass no DEC
+            {
+                "CHILD": "child4",
+                "DEC": "01/01/2020",
+            },  # Born 01/01/2002, 18 before DEC, FAIL
+            {"CHILD": "child6", "DEC": pd.NA},  # Pass no DEC
+            {"CHILD": "child4", "DEC": pd.NA},  # Pass no DEC
+            {
+                "CHILD": "child8",
+                "DEC": "30/03/2020",
+            },  # Born 31/03/2002, within collection year 18 & DEC, but  DEC before BDAY, PASS
+            {
+                "CHILD": "child9",
+                "DEC": "02/04/2019",
+            },  # Born 01/04/2002, within collection birthday 17 & DEC before BDAY, FAIL
+            {
+                "CHILD": "child10",
+                "DEC": "02/04/2019",
+            },  # Born 01/04/2001, within collection birthday 18 & DEC before BDAY, FAIL
         ]
     )
 

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -38,10 +38,13 @@ def validate(dfs):
 
         # Fails rows where the child is between 19 and 17 at the end of a return,
         # and their DEC is after their 17th birthday
+        condition_17 = df_merged["DEC"] >= (df_merged["DOB"] + np.timedelta64(17, "Y"))
+        condition_18 = df_merged["DEC"] >= (df_merged["DOB"] + np.timedelta64(18, "Y"))
+
         df_errors = df_merged[
             (df_merged["AGE_AT_CE"] < np.timedelta64(19, "Y"))
             & (df_merged["AGE_AT_CE"] >= np.timedelta64(17, "Y"))
-            & (df_merged["DEC"] >= (df_merged["DOB"] + np.timedelta64(17, "Y")))
+            & (condition_17 | condition_18)
         ]
 
         df_errors = df_errors[
@@ -60,7 +63,7 @@ def test_validate():
         [
             {
                 "CHILD": "child1",
-                "DOB": "01/01/2001",
+                "DOB": "31/03/2002",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
@@ -107,21 +110,45 @@ def test_validate():
                 "ACTIV": pd.NA,
                 "ACCOM": pd.NA,
             },
+            {
+                "CHILD": "child8",
+                "DOB": "01/09/2002",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child9",
+                "DOB": "01/09/2002",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child10",
+                "DOB": "01/09/2001",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
         ]
     )
 
     fake_epi = pd.DataFrame(
         [
-            {"CHILD": "child1", "DEC": "01/01/2020"},
+            {"CHILD": "child1", "DEC": "31/03/2020"},
             {"CHILD": "child2", "DEC": pd.NA},
             {"CHILD": "child3", "DEC": pd.NA},
             {"CHILD": "child4", "DEC": "01/01/2020"},
             {"CHILD": "child6", "DEC": pd.NA},
             {"CHILD": "child4", "DEC": pd.NA},
+            {"CHILD": "child8", "DEC": "31/08/20020"},
+            {"CHILD": "child9", "DEC": "02/09/2020"},
+            {"CHILD": "child10", "DEC": "02/09/2020"},
         ]
     )
 
-    metadata = {"collection_end": pd.to_datetime("01/01/2020", format="%d/%m/%Y")}
+    metadata = {"collection_end": pd.to_datetime("31/03/2020", format="%d/%m/%Y")}
 
     fake_dfs = {
         "Episodes": fake_epi,
@@ -131,4 +158,4 @@ def test_validate():
 
     result = validate(fake_dfs)
 
-    assert result == {"OC3": [0, 3]}
+    assert result == {"OC3": [0, 3, 8, 9]}

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -19,6 +19,12 @@ def validate(dfs):
     else:
         df = dfs["OC3"]
         collection_end = dfs["metadata"]["collection_end"]
+
+        df["DOB"] = pd.to_datetime(df["DOB"], format="%d/%m/%Y")
+        collection_end = pd.to_datetime(
+            collection_end, format="%d/%m/%Y", errors="coerce"
+        )
+
         df = df.reset_index()
 
         df["AGE_AT_CE"] = collection_end - df["DOB"]
@@ -72,7 +78,6 @@ def test_validate():
         ]
     )
 
-    fake_data["DOB"] = pd.to_datetime(fake_data["DOB"], format="%d/%m/%Y")
     metadata = {"collection_end": pd.to_datetime("01/01/2020", format="%d/%m/%Y")}
 
     fake_dfs = {

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -36,6 +36,8 @@ def validate(dfs):
 
         df_merged = OC3.merge(episodes, on="CHILD", how="left")
 
+        # Fails rows where the child is between 19 and 17 at the end of a return,
+        # and their DEC is after their 17th birthday
         df_errors = df_merged[
             (df_merged["AGE_AT_CE"] < np.timedelta64(19, "Y"))
             & (df_merged["AGE_AT_CE"] >= np.timedelta64(17, "Y"))

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -14,7 +14,7 @@ def validate(dfs):
     # and
     # current episode <DEC> is present and after the birthdate then
     # <IN_TOUCH>, <ACTIV> and <ACCOM> should not be provided
-    if ("OC3" not in dfs) & ("Episodes" not in dfs):
+    if ("OC3" not in dfs) | ("Episodes" not in dfs):
         return {}
     else:
         OC3 = dfs["OC3"]
@@ -34,7 +34,7 @@ def validate(dfs):
 
         OC3["AGE_AT_CE"] = collection_end - OC3["DOB"]
 
-        df_merged = OC3.merge(episodes, on="CHILD", how="left")
+        df_merged = OC3.merge(episodes, on="CHILD", how="inner")
 
         # Fails rows where the child is between 19 and 17 at the end of a return,
         # and their DEC is after their 17th birthday

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -85,63 +85,77 @@ def test_validate():
             },
             {
                 "CHILD": "child2",
-                "DOB": "01/01/2001",
-                "IN_TOUCH": pd.NA,
-                "ACTIV": pd.NA,
-                "ACCOM": pd.NA,
-            },
-            {
-                "CHILD": "child3",
-                "DOB": "01/01/2000",
-                "IN_TOUCH": "Y",
-                "ACTIV": "Y",
-                "ACCOM": "Y",
-            },
-            {
-                "CHILD": "child4",
-                "DOB": "01/01/2002",
-                "IN_TOUCH": "Y",
-                "ACTIV": "Y",
-                "ACCOM": "Y",
-            },
-            {
-                "CHILD": "child5",
-                "DOB": "01/01/2002",
-                "IN_TOUCH": "Y",
-                "ACTIV": "Y",
-                "ACCOM": "Y",
-            },
-            {
-                "CHILD": "child6",
-                "DOB": "01/01/2002",
-                "IN_TOUCH": "Y",
-                "ACTIV": "Y",
-                "ACCOM": "Y",
-            },
-            {
-                "CHILD": "child7",
-                "DOB": "01/01/2002",
-                "IN_TOUCH": pd.NA,
-                "ACTIV": pd.NA,
-                "ACCOM": pd.NA,
-            },
-            {
-                "CHILD": "child8",
                 "DOB": "31/03/2002",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
             },
             {
+                "CHILD": "child3",
+                "DOB": "31/03/2002",
+                "IN_TOUCH": pd.NA,
+                "ACTIV": pd.NA,
+                "ACCOM": pd.NA,
+            },
+            {
+                "CHILD": "child4",
+                "DOB": "31/03/2003",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child5",
+                "DOB": "31/03/2003",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child6",
+                "DOB": "31/03/2002",
+                "IN_TOUCH": pd.NA,
+                "ACTIV": pd.NA,
+                "ACCOM": pd.NA,
+            },
+            {
+                "CHILD": "child7",
+                "DOB": "01/01/2002",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },  # Not in EPI file, IGNORE
+            {
+                "CHILD": "child8",
+                "DOB": "31/03/2004",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
                 "CHILD": "child9",
-                "DOB": "01/04/2002",
+                "DOB": "31/03/2004",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
             },
             {
                 "CHILD": "child10",
-                "DOB": "01/04/2001",
+                "DOB": "31/03/2002",
+                "IN_TOUCH": pd.NA,
+                "ACTIV": pd.NA,
+                "ACCOM": pd.NA,
+            },
+            {
+                "CHILD": "child11",
+                "DOB": "31/03/2002",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child12",
+                "DOB": "31/03/2003",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
@@ -155,26 +169,46 @@ def test_validate():
                 "CHILD": "child1",
                 "DEC": "31/03/2020",
             },  # 18 within collection year and BDAY on DEC,  FAIL
-            {"CHILD": "child2", "DEC": pd.NA},  # Pass no DEC
-            {"CHILD": "child3", "DEC": pd.NA},  # Pass no DEC
+            {
+                "CHILD": "child2",
+                "DEC": "30/03/2020",
+            },  # 18 within collection year and BDAY after DEC, PASS
+            {
+                "CHILD": "child3",
+                "DEC": "31/03/2020",
+            },  # 18 within collection year and BDAY on DEC with no IN TOUCH, PASS
             {
                 "CHILD": "child4",
+                "DEC": "31/03/2020",
+            },  # 17 within collection year and BDAY on DEC, FAIL
+            {
+                "CHILD": "child5",
                 "DEC": "01/01/2020",
-            },  # Born 01/01/2002, 18 before DEC, FAIL
-            {"CHILD": "child6", "DEC": pd.NA},  # Pass no DEC
-            {"CHILD": "child4", "DEC": pd.NA},  # Pass no DEC
+            },  # 17 within collection year and BDAY after DEC, PASS
+            {
+                "CHILD": "child6",
+                "DEC": "31/03/2020",
+            },  # 17 within collection year and BDAY on DEC with no IN TOUCH, PASS
             {
                 "CHILD": "child8",
-                "DEC": "30/03/2020",
-            },  # Born 31/03/2002, within collection year 18 & DEC, but  DEC before BDAY, PASS
+                "DEC": "31/03/2020",
+            },  # 16 within collection year and BDAY on DEC, IGNORE
             {
                 "CHILD": "child9",
-                "DEC": "02/04/2019",
-            },  # Born 01/04/2002, within collection birthday 17 & DEC before BDAY, FAIL
+                "DEC": "30/03/2020",
+            },  # 16 within collection year and BDAY after DEC, IGNORE
             {
                 "CHILD": "child10",
-                "DEC": "02/04/2019",
-            },  # Born 01/04/2001, within collection birthday 18 & DEC before BDAY, FAIL
+                "DEC": "30/03/2020",
+            },  # 18 within collection year and BDAY before DEC but no IN TOUCH, IGNORE
+            {
+                "CHILD": "child11",
+                "DEC": pd.NA,
+            },  # 18 within collection year but no DEC, IGNORE
+            {
+                "CHILD": "child12",
+                "DEC": pd.NA,
+            },  # 17 within collection year but no DEC, IGNORE
         ]
     )
 
@@ -188,4 +222,4 @@ def test_validate():
 
     result = validate(fake_dfs)
 
-    assert result == {"OC3": [0, 3, 8, 9]}
+    assert result == {"OC3": [0, 3]}

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -38,13 +38,25 @@ def validate(dfs):
 
         # Fails rows where the child is between 19 and 17 at the end of a return,
         # and their DEC is after their 17th birthday
-        condition_17 = df_merged["DEC"] >= (df_merged["DOB"] + np.timedelta64(17, "Y"))
-        condition_18 = df_merged["DEC"] >= (df_merged["DOB"] + np.timedelta64(18, "Y"))
+        df_merged['age at dec'] = (df_merged['DEC'] - df_merged['DOB']) / np.timedelta64(1, "Y")
+    
+        condition_17 = df_merged["DEC"] >= (df_merged["DOB"] + pd.offsets.DateOffset(years=17))
+        condition_18 = df_merged["DEC"] >= (df_merged["DOB"] + pd.offsets.DateOffset(years=18))
+        print(df_merged)
+        print(df_merged[condition_18])
 
         df_errors = df_merged[
-            (df_merged["AGE_AT_CE"] < np.timedelta64(19, "Y"))
-            & (df_merged["AGE_AT_CE"] >= np.timedelta64(17, "Y"))
-            & (condition_17 | condition_18)
+            (
+                (df_merged["AGE_AT_CE"] >= np.timedelta64(17, "Y")) & 
+                 (df_merged["AGE_AT_CE"] < np.timedelta64(18, "Y"))  & 
+                 condition_17
+                 )
+            | (
+                (df_merged["AGE_AT_CE"] >= np.timedelta64(18, "Y")) & 
+                 (df_merged["AGE_AT_CE"] < np.timedelta64(19, "Y")) & 
+                 condition_18
+                 )
+            
         ]
 
         df_errors = df_errors[
@@ -69,14 +81,14 @@ def test_validate():
                 "ACCOM": "Y",
             },
             {
-                "CHILD": "child2",
+                "CHILD": "child2", 
                 "DOB": "01/01/2001",
                 "IN_TOUCH": pd.NA,
                 "ACTIV": pd.NA,
                 "ACCOM": pd.NA,
             },
             {
-                "CHILD": "child3",
+                "CHILD": "child3", 
                 "DOB": "01/01/2000",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
@@ -112,21 +124,21 @@ def test_validate():
             },
             {
                 "CHILD": "child8",
-                "DOB": "01/09/2002",
+                "DOB": "31/03/2002",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
             },
             {
                 "CHILD": "child9",
-                "DOB": "01/09/2002",
+                "DOB": "01/04/2002",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
             },
             {
                 "CHILD": "child10",
-                "DOB": "01/09/2001",
+                "DOB": "01/04/2001",
                 "IN_TOUCH": "Y",
                 "ACTIV": "Y",
                 "ACCOM": "Y",
@@ -136,15 +148,15 @@ def test_validate():
 
     fake_epi = pd.DataFrame(
         [
-            {"CHILD": "child1", "DEC": "31/03/2020"},
-            {"CHILD": "child2", "DEC": pd.NA},
-            {"CHILD": "child3", "DEC": pd.NA},
-            {"CHILD": "child4", "DEC": "01/01/2020"},
-            {"CHILD": "child6", "DEC": pd.NA},
-            {"CHILD": "child4", "DEC": pd.NA},
-            {"CHILD": "child8", "DEC": "31/08/20020"},
-            {"CHILD": "child9", "DEC": "02/09/2020"},
-            {"CHILD": "child10", "DEC": "02/09/2020"},
+            {"CHILD": "child1", "DEC": "31/03/2020"}, # 18 within collection year and BDAY on DEC,  FAIL
+            {"CHILD": "child2", "DEC": pd.NA}, # Pass no DEC
+            {"CHILD": "child3", "DEC": pd.NA}, # Pass no DEC
+            {"CHILD": "child4", "DEC": "01/01/2020"}, # Born 01/01/2002, 18 before DEC, FAIL
+            {"CHILD": "child6", "DEC": pd.NA}, # Pass no DEC
+            {"CHILD": "child4", "DEC": pd.NA}, # Pass no DEC
+            {"CHILD": "child8", "DEC": "30/03/2020"}, # Born 31/03/2002, within collection year 18 & DEC, but  DEC before BDAY, PASS
+            {"CHILD": "child9", "DEC": "02/04/2019"}, # Born 01/04/2002, within collection birthday 17 & DEC before BDAY, FAIL
+            {"CHILD": "child10", "DEC": "02/04/2019"}, # Born 01/04/2001, within collection birthday 18 & DEC before BDAY, FAIL
         ]
     )
 

--- a/lac_validator/rules/lac2023_24/rule_1016.py
+++ b/lac_validator/rules/lac2023_24/rule_1016.py
@@ -1,0 +1,85 @@
+import pandas as pd
+import numpy as np
+
+from lac_validator.rule_engine import rule_definition
+
+
+@rule_definition(
+    code="1016",
+    message="If the child ceases to be looked after in the year, but is still looked after on or after their 17th or on their 18th birthday, then information on their activity and accommodation is not required.Please delete the OC3 information.",
+    affected_fields=["IN_TOUCH", "ACTIV", "ACCOM"],
+)
+def validate(dfs):
+    # If <DOB> < 19 and >= to 17 years prior to <COLLECTION_END_DATE>
+    # and
+    # current episode <DEC> is present and after the birthdate then
+    # <IN_TOUCH>, <ACTIV> and <ACCOM> should not be provided
+    if "OC3" not in dfs:
+        return {}
+    else:
+        df = dfs["OC3"]
+        collection_end = dfs["metadata"]["collection_end"]
+        df = df.reset_index()
+
+        df["AGE_AT_CE"] = collection_end - df["DOB"]
+        df_errors = df[
+            (df["AGE_AT_CE"] < np.timedelta64(19, "Y"))
+            & (df["AGE_AT_CE"] >= np.timedelta64(17, "Y"))
+        ]
+
+        df_errors = df_errors[
+            df_errors["IN_TOUCH"].notna()
+            | df_errors["ACTIV"].notna()
+            | df_errors["ACCOM"].notna()
+        ]
+
+        return {"OC3": df_errors["index"].tolist()}
+
+
+def test_validate():
+    import pandas as pd
+
+    fake_data = pd.DataFrame(
+        [
+            {
+                "CHILD": "child1",
+                "DOB": "01/01/2001",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child2",
+                "DOB": "01/01/2001",
+                "IN_TOUCH": pd.NA,
+                "ACTIV": pd.NA,
+                "ACCOM": pd.NA,
+            },
+            {
+                "CHILD": "child3",
+                "DOB": "01/01/2000",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+            {
+                "CHILD": "child4",
+                "DOB": "01/01/2002",
+                "IN_TOUCH": "Y",
+                "ACTIV": "Y",
+                "ACCOM": "Y",
+            },
+        ]
+    )
+
+    fake_data["DOB"] = pd.to_datetime(fake_data["DOB"], format="%d/%m/%Y")
+    metadata = {"collection_end": pd.to_datetime("01/01/2020", format="%d/%m/%Y")}
+
+    fake_dfs = {
+        "OC3": fake_data,
+        "metadata": metadata,
+    }
+
+    result = validate(fake_dfs)
+
+    assert result == {"OC3": [0, 3]}


### PR DESCRIPTION
closes #693 

Adds 1016 to 23/24
Uses np.timedeltas to calculate ages, which I think is fine, but I don't know if there's some obscure reason where it may not catch edge cases say if someone has been alive for 19 years but somehow isn't 19, or something, I'm not sure if there was a standard way of doing it for the validator I'm not aware of.