### PR TITLE
updates collection year function in datastore to reflect new FE

### DIFF
--- a/lac_validator/datastore.py
+++ b/lac_validator/datastore.py
@@ -71,8 +71,8 @@ def create_datastore(data: Dict[str, Any], metadata: Dict[str, Any]):
 
 def _process_metadata(metadata):
     collection_year = int(metadata["collectionYear"][:4])
-    metadata["collection_start"] = f"01/04/{collection_year}"
-    metadata["collection_end"] = f"31/03/{collection_year + 1}"
+    metadata["collection_start"] = f"01/04/{collection_year - 1}"
+    metadata["collection_end"] = f"31/03/{collection_year}"
     return metadata
 
 


### PR DESCRIPTION
Fixes a bug where validation rules using collection year (e.g. 205B and 351) failed children as having been present in the previous year, when they weren't, as the validator was calculating what the current year was wrong.

This is because the original FE passed the year the collections started and used that to calculate collection dates, and the new FE passes the end of the collection, but the same calculation as performed to calculate collection dates, making dates one year in the future of what they should be.

Updates the relevant function to correctly have collection_start as 1 year less than the year the FE passes, and collection_end as the year the FE passes, rather than the collection_start as the year the FE passes and collection_end one year higher than this.