### PR TITLE
Fixed bug in scpch ingress check function

### DIFF
--- a/lac_validator/ingress.py
+++ b/lac_validator/ingress.py
@@ -680,7 +680,7 @@ def combined_ch_scp_check(excel_to_check):
     Only runs in instances where the number fo files uploaded in the SCP/CH boxes is one.
     """
     if not isinstance(excel_to_check, bytes):
-        CH_bytes = excel_to_check.tobytes()
+        CH_bytes = excel_to_check['file_content'].tobytes()
     else:
         CH_bytes = excel_to_check
     df = pd.read_excel(CH_bytes, engine="openpyxl")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csc-validator-be-903"
-version = "0.1.1"
+version = "0.1.2"
 description = "Shared module for validating SSDA903 census data using DfE rules."
 authors = ["Michael Ogunkolade <michael.ogunkolade@socialfinance.org.uk>", "Kaj Siebert <kaj.siebert@socialfinance.org.uk>", "Tambe Tabitha Achere <tambe.tabitha@socialfinance.org.uk>", "Mark Waddoups <mark.waddoups@socialfinance.org.uk>", "DatatoInsight's children's social care analyst community <datatoinsight.enquiries@gmail.com>"]
 repository = "https://github.com/data-to-insight/csc-validator-be-903"

--- a/tests/test_ingress.py
+++ b/tests/test_ingress.py
@@ -178,7 +178,7 @@ def test_combined_ch_scp_check(dummy_chscp):
         ch_path_dir,
         scp_path_dir,
         combined_path_dir,
-        combined["file_content"],
+        combined,
     ) = dummy_chscp
 
     with pytest.raises(UploadError):
@@ -187,7 +187,7 @@ def test_combined_ch_scp_check(dummy_chscp):
     with pytest.raises(UploadError):
         combined_ch_scp_check(ch["file_content"])
 
-    combined_outcome = combined_ch_scp_check(combined["file_content"])
+    combined_outcome = combined_ch_scp_check(combined)
     assert combined_outcome == True
 
 


### PR DESCRIPTION
Fixed bug in which dict containing data, rather than data itself is passed from the front end to the function that checks if a combined SCP/CH file is uploaded.

Fixed relevant tests.