### PR TITLE
SW04STG1

### DIFF
--- a/lac_validator/rules/lac2022_23/rule_632.py
+++ b/lac_validator/rules/lac2022_23/rule_632.py
@@ -13,6 +13,7 @@ def validate(dfs):
         return {}
     else:
         import lac_validator.rules.rule_utils
+
         # function to check that date is of the right format
 
         episodes = dfs["Episodes"]
@@ -22,8 +23,10 @@ def validate(dfs):
         episodes["DECOM"] = pd.to_datetime(
             episodes["DECOM"], format="%d/%m/%Y", errors="coerce"
         )
-        prevperm["DATE_PERM_dt"] = prevperm["DATE_PERM"].apply(lac_validator.rules.rule_utils.valid_date)
-        
+        prevperm["DATE_PERM_dt"] = prevperm["DATE_PERM"].apply(
+            lac_validator.rules.rule_utils.valid_date
+        )
+
         # if nans aren't dropped, idxmin() won't work. we can do this since dropping nan DECOMs doesn't affect the rule logic.
         decom_only_eps = episodes[["CHILD", "DECOM"]].dropna()
 
@@ -40,8 +43,7 @@ def validate(dfs):
 
         # If provided <DATE_PERM> should be prior to <DECOM> and in a valid format and contain a valid date Format should be DD/MM/YYYY or one or more elements of the date can be replaced by ZZ if part of the date element is not known.
         mask = (merged["DATE_PERM_dt"] >= merged["DECOM"]) | (
-            merged["DATE_PERM"].notna()
-            & merged["DATE_PERM_dt"].isna()
+            merged["DATE_PERM"].notna() & merged["DATE_PERM_dt"].isna()
         )
 
         # error locations

--- a/lac_validator/rules/lac2022_23/rule_632.py
+++ b/lac_validator/rules/lac2022_23/rule_632.py
@@ -12,51 +12,8 @@ def validate(dfs):
     if "Episodes" not in dfs or "PrevPerm" not in dfs:
         return {}
     else:
+        import lac_validator.rules.rule_utils
         # function to check that date is of the right format
-        def valid_date(dte):
-            try:
-                lst = dte.split("/")
-            except AttributeError:
-                return pd.NaT
-            # Preceding block checks for the scenario where the value passed in is nan/naT
-
-            # date should have three elements
-            if len(lst) != 3:
-                return pd.NaT
-
-            z_list = ["ZZ", "ZZ", "ZZZZ"]
-            # We set the date to the latest possible value to avoid false positives
-            offset_list = [
-                pd.DateOffset(months=1, days=-1),
-                pd.DateOffset(years=1, days=-1),
-                None,
-            ]
-            # that is, go to the next month/year and take the day before that
-            already_found_non_zeds = False
-            date_bits = []
-
-            for i, zeds, offset in zip(lst, z_list, offset_list):
-                if i == zeds:
-                    # I'm assuming it is invalid to have a date like '01/ZZ/ZZZZ'
-                    if already_found_non_zeds:
-                        return pd.NaT
-                    # Replace day & month zeds with '01' so we can check if the resulting date is valid
-                    # and set the offset so we can compare the latest corresponding date
-                    elif i == "ZZ":
-                        i = "01"
-                        offset_to_use = offset
-                else:
-                    already_found_non_zeds = True
-                date_bits.append(i)
-
-            as_datetime = pd.to_datetime(
-                "/".join(date_bits), format="%d/%m/%Y", errors="coerce"
-            )
-            try:
-                as_datetime += offset_to_use
-            except NameError:  # offset_to_use only defined if needed
-                pass
-            return as_datetime
 
         episodes = dfs["Episodes"]
         prevperm = dfs["PrevPerm"]
@@ -65,8 +22,8 @@ def validate(dfs):
         episodes["DECOM"] = pd.to_datetime(
             episodes["DECOM"], format="%d/%m/%Y", errors="coerce"
         )
-        prevperm["DATE_PERM_dt"] = prevperm["DATE_PERM"].apply(valid_date)
-
+        prevperm["DATE_PERM_dt"] = prevperm["DATE_PERM"].apply(lac_validator.rules.rule_utils.valid_date)
+        
         # if nans aren't dropped, idxmin() won't work. we can do this since dropping nan DECOMs doesn't affect the rule logic.
         decom_only_eps = episodes[["CHILD", "DECOM"]].dropna()
 
@@ -85,7 +42,6 @@ def validate(dfs):
         mask = (merged["DATE_PERM_dt"] >= merged["DECOM"]) | (
             merged["DATE_PERM"].notna()
             & merged["DATE_PERM_dt"].isna()
-            & (merged["DATE_PERM"] != "ZZ/ZZ/ZZZZ")
         )
 
         # error locations
@@ -153,7 +109,7 @@ def test_validate():
             {
                 "CHILD": "105",
                 "DECOM": "01/03/2021",
-            },  # 5 - fail! DATE_PERM wrong format
+            },  # 5 - Pass
             {
                 "CHILD": "106",
                 "DECOM": "01/07/2021",
@@ -185,4 +141,4 @@ def test_validate():
 
     result = validate(fake_dfs)
     # desired
-    assert result == {"Episodes": [0, 2, 5, 9, 10], "PrevPerm": [0, 1, 4, 8, 9]}
+    assert result == {"Episodes": [0, 2, 9, 10], "PrevPerm": [0, 1, 8, 9]}

--- a/lac_validator/rules/lac2023_24/rule_SW04STG1.py
+++ b/lac_validator/rules/lac2023_24/rule_SW04STG1.py
@@ -1,0 +1,76 @@
+import pandas as pd
+
+from lac_validator.rule_engine import rule_definition
+
+
+@rule_definition(
+    code="SW04STG1",
+    message="Date social worker episode began is not a valid date..",
+    affected_fields=["SW_DECOM"],
+)
+def validate(dfs):
+    if "SWEpisodes" not in dfs:
+        return {}
+    else:
+        df = dfs["SWEpisodes"]
+
+        # function to check that date is of the right format
+        def valid_date(dte):
+            try:
+                lst = dte.split("/")
+            except AttributeError:
+                return pd.NaT
+            # Preceding block checks for the scenario where the value passed in is nan/naT
+
+            # date should have three elements
+            if len(lst) != 3:
+                return pd.NaT
+
+            z_list = ["ZZ", "ZZ", "ZZZZ"]
+            # We set the date to the latest possible value to avoid false positives
+            offset_list = [
+                pd.DateOffset(months=1, days=-1),
+                pd.DateOffset(years=1, days=-1),
+                None,
+            ]
+            # that is, go to the next month/year and take the day before that
+            date_bits = []
+
+            for i, zeds, offset in zip(lst, z_list, offset_list):
+                if i == "ZZ":
+                    i = "01"
+                    offset_to_use = offset
+                elif i == "ZZZZ":
+                    i = "2000"
+                date_bits.append(i)
+
+            as_datetime = pd.to_datetime(
+                "/".join(date_bits), format="%d/%m/%Y", errors="coerce"
+            )
+            try:
+                as_datetime += offset_to_use
+            except NameError:  # offset_to_use only defined if needed
+                pass
+            return as_datetime
+
+        df["SW_DECOM_dt"] = df["SW_DECOM"].apply(valid_date)
+
+        error_rows = df[df["SW_DECOM_dt"].isna()].index
+
+        return {"SWEpisodes": error_rows.tolist()}
+
+
+def test_validate():
+    import pandas as pd
+
+    fake_data = pd.DataFrame(
+        {
+            "SW_DECOM": ["ZZ/ZZ/ZZZZ", "01/01/2001", "zz", "01/01/ZZZZ", pd.NA],
+        }
+    )
+
+    fake_dfs = {"SWEpisodes": fake_data}
+
+    result = validate(fake_dfs)
+
+    assert result == {"SWEpisodes": [2, 4]}

--- a/lac_validator/rules/lac2023_24/rule_SW04STG1.py
+++ b/lac_validator/rules/lac2023_24/rule_SW04STG1.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from lac_validator.rule_engine import rule_definition
 
-
 @rule_definition(
     code="SW04STG1",
     message="Date social worker episode began is not a valid date..",
@@ -12,48 +11,10 @@ def validate(dfs):
     if "SWEpisodes" not in dfs:
         return {}
     else:
+        import lac_validator.rules.rule_utils
         df = dfs["SWEpisodes"]
 
-        # function to check that date is of the right format
-        def valid_date(dte):
-            try:
-                lst = dte.split("/")
-            except AttributeError:
-                return pd.NaT
-            # Preceding block checks for the scenario where the value passed in is nan/naT
-
-            # date should have three elements
-            if len(lst) != 3:
-                return pd.NaT
-
-            z_list = ["ZZ", "ZZ", "ZZZZ"]
-            # We set the date to the latest possible value to avoid false positives
-            offset_list = [
-                pd.DateOffset(months=1, days=-1),
-                pd.DateOffset(years=1, days=-1),
-                None,
-            ]
-            # that is, go to the next month/year and take the day before that
-            date_bits = []
-
-            for i, zeds, offset in zip(lst, z_list, offset_list):
-                if i == "ZZ":
-                    i = "01"
-                    offset_to_use = offset
-                elif i == "ZZZZ":
-                    i = "2000"
-                date_bits.append(i)
-
-            as_datetime = pd.to_datetime(
-                "/".join(date_bits), format="%d/%m/%Y", errors="coerce"
-            )
-            try:
-                as_datetime += offset_to_use
-            except NameError:  # offset_to_use only defined if needed
-                pass
-            return as_datetime
-
-        df["SW_DECOM_dt"] = df["SW_DECOM"].apply(valid_date)
+        df["SW_DECOM_dt"] = df["SW_DECOM"].apply(lac_validator.rules.rule_utils.valid_date)
 
         error_rows = df[df["SW_DECOM_dt"].isna()].index
 

--- a/lac_validator/rules/lac2023_24/rule_SW04STG1.py
+++ b/lac_validator/rules/lac2023_24/rule_SW04STG1.py
@@ -20,7 +20,7 @@ def validate(dfs):
             lac_validator.rules.rule_utils.valid_date
         )
 
-        error_rows = df[df["SW_DECOM_dt"].isna()].index
+        error_rows = df[(df["SW_DECOM_dt"].isna()) & (~df["SW_DECOM"].isna())].index
 
         return {"SWEpisodes": error_rows.tolist()}
 
@@ -38,4 +38,4 @@ def test_validate():
 
     result = validate(fake_dfs)
 
-    assert result == {"SWEpisodes": [2, 4]}
+    assert result == {"SWEpisodes": [2]}

--- a/lac_validator/rules/lac2023_24/rule_SW04STG1.py
+++ b/lac_validator/rules/lac2023_24/rule_SW04STG1.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from lac_validator.rule_engine import rule_definition
 
+
 @rule_definition(
     code="SW04STG1",
     message="Date social worker episode began is not a valid date..",
@@ -12,9 +13,12 @@ def validate(dfs):
         return {}
     else:
         import lac_validator.rules.rule_utils
+
         df = dfs["SWEpisodes"]
 
-        df["SW_DECOM_dt"] = df["SW_DECOM"].apply(lac_validator.rules.rule_utils.valid_date)
+        df["SW_DECOM_dt"] = df["SW_DECOM"].apply(
+            lac_validator.rules.rule_utils.valid_date
+        )
 
         error_rows = df[df["SW_DECOM_dt"].isna()].index
 

--- a/lac_validator/rules/rule_utils.py
+++ b/lac_validator/rules/rule_utils.py
@@ -73,3 +73,41 @@ def field_different_from_previous(dfs, field):
         err_list = merged_co["index"][err_mask].unique().tolist()
         err_list.sort()
         return {"Episodes": err_list}
+    
+def valid_date(dte):
+    try:
+        lst = dte.split("/")
+    except AttributeError:
+        return pd.NaT
+    # Preceding block checks for the scenario where the value passed in is nan/naT
+
+    # date should have three elements
+    if len(lst) != 3:
+        return pd.NaT
+
+    z_list = ["ZZ", "ZZ", "ZZZZ"]
+    # We set the date to the latest possible value to avoid false positives
+    offset_list = [
+        pd.DateOffset(months=1, days=-1),
+        pd.DateOffset(years=1, days=-1),
+        None,
+    ]
+    # that is, go to the next month/year and take the day before that
+    date_bits = []
+
+    for i, zeds, offset in zip(lst, z_list, offset_list):
+        if i == "ZZ":
+            i = "01"
+            offset_to_use = offset
+        elif i == "ZZZZ":
+            i = "2000"
+        date_bits.append(i)
+
+    as_datetime = pd.to_datetime(
+        "/".join(date_bits), format="%d/%m/%Y", errors="coerce"
+    )
+    try:
+        as_datetime += offset_to_use
+    except (NameError, TypeError):  # offset_to_use only defined if needed
+        pass
+    return as_datetime

--- a/lac_validator/rules/rule_utils.py
+++ b/lac_validator/rules/rule_utils.py
@@ -73,7 +73,8 @@ def field_different_from_previous(dfs, field):
         err_list = merged_co["index"][err_mask].unique().tolist()
         err_list.sort()
         return {"Episodes": err_list}
-    
+
+
 def valid_date(dte):
     try:
         lst = dte.split("/")


### PR DESCRIPTION
closes #672 

This is another slightly weird one. I cannibalised the code from 632 to do it, but have changed it to allow any and all date values to be ZZs in line with the wording of the rule, but I'm not sure if that's how the guidance is meant to be interpreted.

I do wonder if this is possible without a for loop. I tried to do it from scratch but realised if 632 was in, it may be the best way of doing it.