### PR TITLE
Update black version in linting.yaml

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          version: "22.8.0"
+          version: "23.7.0"


### PR DESCRIPTION
updates the version of black used in linting to the version used in poetry to stop errors occurring when different version of black require different formats