### PR TITLE
fix syntax in publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,8 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-+     # IMPORTANT: this permission is mandatory for trusted publishing
-+     id-token: write
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes syntax error that [caused tests to fail ](https://github.com/data-to-insight/csc-validator-be-903/actions/runs/9544870047/workflow)at the merge step.

Related to https://github.com/data-to-insight/csc-validator-be-903/pull/785