### PR TITLE
Update rule 213

### DIFF
--- a/lac_validator/rules/lac2025_26/rule_213.py
+++ b/lac_validator/rules/lac2025_26/rule_213.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+from lac_validator.rule_engine import rule_definition
+
+
+@rule_definition(
+    code="213",
+    message="Placement provider information not required.",
+    affected_fields=["PLACE_PROVIDER"],
+    tables=["Episodes"],
+)
+def validate(dfs):
+    if "Episodes" not in dfs:
+        return {}
+    else:
+        df = dfs["Episodes"]
+        mask = (
+            df["PLACE"].isin(["T0", "T1", "T2", "T3", "T4", "Z11", "Z12", "Z13", "Z14"])
+            & df["PLACE_PROVIDER"].notna()
+        )
+        return {"Episodes": df.index[mask].tolist()}
+
+def test_validate():
+    import pandas as pd
+
+    fake_data = pd.DataFrame(
+        {
+            "PLACE": ["T0", "U6", "U1", "U4", "P1", "T2", "T3", pd.NA, "Z1", "Z1", "Z11", "Z12", "Z13", "Z14"],
+            "PLACE_PROVIDER": [
+                pd.NA,
+                pd.NA,
+                "PR3",
+                "PR4",
+                "PR0",
+                "PR2",
+                "PR1",
+                pd.NA,
+                pd.NA,
+                "notna",
+                pd.NA,
+                pd.NA,
+                "value", # Fail
+                "PR6" # Fail
+            ],
+        }
+    )
+
+    fake_dfs = {"Episodes": fake_data}
+
+    result = validate(fake_dfs)
+
+    assert result == {"Episodes": [5, 6, 12, 13]}

--- a/lac_validator/rules/lac2025_26/rule_213.py
+++ b/lac_validator/rules/lac2025_26/rule_213.py
@@ -20,12 +20,28 @@ def validate(dfs):
         )
         return {"Episodes": df.index[mask].tolist()}
 
+
 def test_validate():
     import pandas as pd
 
     fake_data = pd.DataFrame(
         {
-            "PLACE": ["T0", "U6", "U1", "U4", "P1", "T2", "T3", pd.NA, "Z1", "Z1", "Z11", "Z12", "Z13", "Z14"],
+            "PLACE": [
+                "T0",
+                "U6",
+                "U1",
+                "U4",
+                "P1",
+                "T2",
+                "T3",
+                pd.NA,
+                "Z1",
+                "Z1",
+                "Z11",
+                "Z12",
+                "Z13",
+                "Z14",
+            ],
             "PLACE_PROVIDER": [
                 pd.NA,
                 pd.NA,
@@ -39,8 +55,8 @@ def test_validate():
                 "notna",
                 pd.NA,
                 pd.NA,
-                "value", # Fail
-                "PR6" # Fail
+                "value",  # Fail
+                "PR6",  # Fail
             ],
         }
     )


### PR DESCRIPTION
Adds PL codes for 25/26

If <PL> = ‘T0’ or ‘T1’ or ‘T2’ or ‘T3’ or 
‘T4’ or ‘Z11’ or ‘Z12’, or ‘Z13’, ‘Z14’ then
<PLACE_PROVIDER> should not be 
provided