### PR TITLE
move deleted rules from 25/26 to 24/25

### DIFF
--- a/lac_validator/rules/lac2024_25/__init__.py
+++ b/lac_validator/rules/lac2024_25/__init__.py
@@ -25,6 +25,9 @@ del_list: list[str] = [
     "SW11aSTG2",
     "SW14STG2",
     "SW15STG2",
+    "SW16aSTG2",
+    "SW16bSTG2",
+    "SW16cSTG2",
 ]
 this_year_config = YearConfig(
     deleted=del_list, added_or_modified=this_year_validator_funcs

--- a/lac_validator/rules/lac2025_26/__init__.py
+++ b/lac_validator/rules/lac2025_26/__init__.py
@@ -12,7 +12,7 @@ this_year_validator_funcs: dict[str, RuleDefinition] = extract_validator_functio
     files
 )
 # if any rules need to be deleted, add their codes as strings into del_list
-del_list: list[str] = ["SW16aSTG2", "SW16cSTG2"]
+del_list: list[str] = []
 this_year_config = YearConfig(
     deleted=del_list, added_or_modified=this_year_validator_funcs
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from lac_validator.utils import (
 def test_get_year_ruleset():
     registry = get_year_ruleset("2025")
 
-    assert len(registry) == 308
+    assert len(registry) == 305
 
     assert isinstance(registry, dict)
     assert isinstance(list(registry.values())[1], RuleDefinition)


### PR DESCRIPTION
Moves deleted rules from 25/26 to 24/25

I originally misinterpreted the DfE guidance not understanding that these changes were for 24/25

> *Aligning to 2024 to 2025 version 1.3
> (New rule: SW17STG2, Amended rules: 174, 393, 607, 612; Deleted rules:SW16aSTG2 - SW16cSTG2. Note: Rules 174, 393, 607 and 612 are marked as amended but changes are to correct a document typo - no change has been made to the rule.)